### PR TITLE
[質問】　field_forのフォームに動的に値を取得させたい。

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -4,7 +4,7 @@ class PlansController < ApplicationController
 
   def new
     @plan = Plan.new
-    @plan.countries.build
+    # @plan.countries.build
   end
 
   def create

--- a/app/views/plans/_country_fields.html.erb
+++ b/app/views/plans/_country_fields.html.erb
@@ -1,14 +1,10 @@
-<tr class= 'nested-fields' >
-  <td>
-    <%= f.text_field :name, placeholder: 'country_name', class:"py-2 px-3 text-gray-700 " %>
+<tr id='country_fields' class= 'nested-fields'>
+  <td><%= f.text_field :name, placeholder: 'country_name', class:"country_name py-2 px-3 text-gray-700 " %>
   </td>
-  <td>
-    <%= f.text_field :latitude, placeholder: 'latitude', class:"py-2 px-3 text-gray-700 " %>
+  <td><%= f.text_field :latitude, placeholder: 'latitude', class:"latitude py-2 px-3 text-gray-700 " %>
   </td>
-  <td>
-    <%= f.text_field :longitude, placeholder: 'longitude', class:"py-2 px-3 text-gray-700" %>
-  </td>  
-  <td>
-    <%= link_to_remove_association "remove task", f, class:'btn btn-danger link link-hover' %>
+  <td><%= f.text_field :longitude, placeholder: 'longitude', class:"longitude py-2 px-3 text-gray-700" %>
+  </td>
+  <td><%= link_to_remove_association "remove", f, class:'remove_bty btn btn-danger link link-hover' %>
   </td>
 </tr>

--- a/app/views/plans/edit.html.erb
+++ b/app/views/plans/edit.html.erb
@@ -1,0 +1,92 @@
+
+
+ <div class="flex flex-col">
+
+  <h1 class='bg-blue-200 m-auto text-5xl'>プラン作成</h1>
+    <div class='flex flex-row'>
+      <div id='map'></div>
+      <%= form_with model: @plan, local: true do |f| %>
+      <div>
+        <div class="form-control flex flex-col">
+          <div class=" shadow-lg rounded px-12 pt-6 pb-8 mb-4 bg-base-100">
+            <input id="address" class="border py-3 px-10 text-gray-700" placeholder="国名を入れてください">
+          </div>
+          <div class=' flex flex-row'>
+            <div>
+              <%= f.label :plan_name, class:"block text-gray-700 font-normal mb-2" %>
+              <%= f.text_field :name, placeholder: 'plan_name', class:" py-2 px-3  text-gray-700 " %>
+            </div>
+            <div class= 'btn btn-secondry' ><%= link_to_add_association 'add country', f, :countries, class: 'hover hover:link',
+                  data: {
+                          association_insertion_node: '#detail-association-insertion-point',
+                          association_insertion_method: 'append' }, onclick:"codeAddress()" %>
+            </div>
+          </div>
+        </div>   
+        <div class="overflow-x-auto">
+          <table class="table w-full">
+            <thead>
+              <tr>
+                <th>country name</th>
+                <th>latitude</th>
+                <th>longitude</th>
+              </tr>
+            </thead>
+            <tbody id='detail-association-insertion-point'>
+                <%= f.fields_for :countries do |country| %>
+                  <%= render 'country_fields', f: country %>
+                <% end %>
+            </tbody>
+          </table>
+                  <div class="form-control mt-6 flex flex-row justify-center">
+                    <div>
+                      <%= f.submit 'build plan', class:'btn btn-primary px-4 py-2 rounded ' %>
+                    </div>
+                  </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+</div> 
+
+<style>
+  #map {
+    height: 700px;
+    width: 80%;
+  }
+</style>
+
+ <script>
+  let map
+  let geocoder
+
+  function initMap(){
+    geocoder = new google.maps.Geocoder()
+
+    map = new google.maps.Map(document.getElementById('map'), {
+      center: {lat: 36.204824, lng:138.252924}, // 日本の位置を初期値とする
+      zoom: 2,
+    });
+  }
+
+  function codeAddress(){
+    let inputAddress = document.getElementById('address').value;
+
+    geocoder.geocode( { 'address': inputAddress}, function(results, status) {
+      if (status == 'OK') {
+        map.setCenter(results[0].geometry.location);
+        var marker = new google.maps.Marker({
+            map: map,
+            position: results[0].geometry.location
+        });
+        document.getElementById('plan_countries_attributes_0_name').value = results[ 0 ].formatted_address.split(/、|\s/, 1);
+        document.getElementById('plan_countries_attributes_0_latitude').value = results[ 0 ].geometry.location.lat();
+        document.getElementById('plan_countries_attributes_0_longitude').value = results[ 0 ].geometry.location.lng();
+      } else {
+        alert('該当する結果がありませんでした：' + status);
+      }
+    });   
+  }
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_API_KEY'] %>&callback=initMap&libraries=places&language=ja" async defer>
+</script> 

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -7,6 +7,12 @@
       <div>
         <div class="form-control flex flex-col">
           <div class=" shadow-lg rounded px-12 pt-6 pb-8 mb-4 bg-base-100">
+          <%
+=begin%>
+  codeAddressは、geocodingAPIをつかっている場所
+  putAddressは、試しに取得したい値を探しているところ
+<%
+=end%>
             <input id="address" class="border py-3 px-10 text-gray-700" placeholder="国名を入れてください">
             <input type="button" value="Search" onclick="codeAddress()">
             <input type="button" value= 'お試し' onclick='putAddress()' >

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -1,4 +1,4 @@
-<div class="flex flex-col">
+ <div class="flex flex-col">
 
   <h1 class='bg-blue-200 m-auto text-5xl'>プラン作成</h1>
     <div class='flex flex-row'>
@@ -8,16 +8,18 @@
         <div class="form-control flex flex-col">
           <div class=" shadow-lg rounded px-12 pt-6 pb-8 mb-4 bg-base-100">
             <input id="address" class="border py-3 px-10 text-gray-700" placeholder="国名を入れてください">
+            <input type="button" value="Search" onclick="codeAddress()">
+            <input type="button" value= 'お試し' onclick='putAddress()' >
           </div>
           <div class=' flex flex-row'>
             <div>
               <%= f.label :plan_name, class:"block text-gray-700 font-normal mb-2" %>
               <%= f.text_field :name, placeholder: 'plan_name', class:" py-2 px-3  text-gray-700 " %>
             </div>
-            <div class= 'btn btn-secondry' ><%= link_to_add_association 'add country', f, :countries, class: 'hover hover:link',
+            <div id='add' class='btn btn-secondry' ><%= link_to_add_association 'add', f, :countries, class: 'hover hover:link',
                   data: {
                           association_insertion_node: '#detail-association-insertion-point',
-                          association_insertion_method: 'append' }, onclick:"codeAddress()" %>
+                          association_insertion_method: 'append' }%>
             </div>
           </div>
         </div>   
@@ -45,20 +47,21 @@
         </div>
       </div>
     </div>
-</div>
+</div> 
 
-    
 <style>
   #map {
     height: 700px;
     width: 80%;
   }
-
 </style>
 
-<script>
+ <script>
   let map
   let geocoder
+  let country_name
+  let contry_latitude
+  let country_longitude
 
   function initMap(){
     geocoder = new google.maps.Geocoder()
@@ -79,14 +82,21 @@
             map: map,
             position: results[0].geometry.location
         });
-        document.getElementById('plan_countries_attributes_0_name').value = results[ 0 ].formatted_address.split(/、|\s/, 1);
-        document.getElementById('plan_countries_attributes_0_latitude').value = results[ 0 ].geometry.location.lat();
-        document.getElementById('plan_countries_attributes_0_longitude').value = results[ 0 ].geometry.location.lng();
       } else {
         alert('該当する結果がありませんでした：' + status);
       }
-    });   
+        country_name = results[ 0 ].formatted_address.split(/、|\s/, 1);
+        country_latitude = results[ 0 ].geometry.location.lat();
+        country_longitude = results[ 0 ].geometry.location.lng();
+        console.log(document.getElementById('address').value)
+    });
+  }
+
+  function putAddress(){
+    let template = document.getElementById('add').getElementsByTagName('a');
+    
+ 
   }
 </script>
 <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_API_KEY'] %>&callback=initMap&libraries=places&language=ja" async defer>
-</script>
+</script> 

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -7,14 +7,8 @@
       <div>
         <div class="form-control flex flex-col">
           <div class=" shadow-lg rounded px-12 pt-6 pb-8 mb-4 bg-base-100">
-          <%
-=begin%>
-  codeAddressは、geocodingAPIをつかっている場所
-  putAddressは、試しに取得したい値を探しているところ
-<%
-=end%>
             <input id="address" class="border py-3 px-10 text-gray-700" placeholder="国名を入れてください">
-            <input type="button" value="Search" onclick="codeAddress()">
+            <input type="button" value="Search" onclick="codeAddress()" >
             <input type="button" value= 'お試し' onclick='putAddress()' >
           </div>
           <div class=' flex flex-row'>
@@ -22,11 +16,10 @@
               <%= f.label :plan_name, class:"block text-gray-700 font-normal mb-2" %>
               <%= f.text_field :name, placeholder: 'plan_name', class:" py-2 px-3  text-gray-700 " %>
             </div>
-            <div id='add' class='btn btn-secondry' ><%= link_to_add_association 'add', f, :countries, class: 'hover hover:link',
+            <%= link_to_add_association 'add', f, :countries, id:'add', class:'btn btn-secondary hover hover:link',
                   data: {
                           association_insertion_node: '#detail-association-insertion-point',
-                          association_insertion_method: 'append' }%>
-            </div>
+                          association_insertion_method: 'append' } %>
           </div>
         </div>   
         <div class="overflow-x-auto">
@@ -68,12 +61,13 @@
   let country_name
   let contry_latitude
   let country_longitude
+  let template
 
   function initMap(){
     geocoder = new google.maps.Geocoder()
 
     map = new google.maps.Map(document.getElementById('map'), {
-      center: {lat: 36.204824, lng:138.252924}, // 日本の位置を初期値とする
+      center: {lat: 36.204824, lng: 138.252924}, // 日本の位置を初期値とする
       zoom: 2,
     });
   }
@@ -94,15 +88,34 @@
         country_name = results[ 0 ].formatted_address.split(/、|\s/, 1);
         country_latitude = results[ 0 ].geometry.location.lat();
         country_longitude = results[ 0 ].geometry.location.lng();
-        console.log(document.getElementById('address').value)
+        
+        template = document.getElementById('add');
+
+        template.outerHTML = `<a id="add" class="btn btn-secondary hover hover:link add_fields" data-association-insertion-node="#detail-association-insertion-point" data-association-insertion-method="append" data-association="country" data-associations="countries" data-association-insertion-template="<tr id='country_fields' class= 'nested-fields'>
+        <td><input placeholder=&quot;country_name&quot; class=&quot;country_name py-2 px-3 text-gray-700 &quot; type=&quot;text&quot; name=&quot;plan[countries_attributes][new_countries][name]&quot; id=&quot;plan_countries_attributes_new_countries_name&quot; value=&quot;${country_name}&quot; />
+        </td>
+        <td><input placeholder=&quot;latitude&quot; class=&quot;latitude py-2 px-3 text-gray-700 &quot; type=&quot;text&quot; name=&quot;plan[countries_attributes][new_countries][latitude]&quot; id=&quot;plan_countries_attributes_new_countries_latitude&quot; value=&quot;${country_latitude}&quot; />
+        </td>
+        <td><input placeholder=&quot;longitude&quot; class=&quot;longitude py-2 px-3 text-gray-700&quot; type=&quot;text&quot; name=&quot;plan[countries_attributes][new_countries][longitude]&quot; id=&quot;plan_countries_attributes_new_countries_longitude&quot; value=&quot;${country_longitude}&quot; />
+        </td>
+        <td><input value=&quot;false&quot; autocomplete=&quot;off&quot; type=&quot;hidden&quot; name=&quot;plan[countries_attributes][new_countries][_destroy]&quot; id=&quot;plan_countries_attributes_new_countries__destroy&quot; /><a class=&quot;remove_bty btn btn-danger link link-hover remove_fields dynamic&quot; href=&quot;#&quot;>remove</a>
+        </td>
+        </tr>
+        " href="#">add</a>`;
+
+        country_name = '';
+        country_latitude = '';
+        country_longitude = '';
+        
     });
+
   }
 
   function putAddress(){
-    let template = document.getElementById('add').getElementsByTagName('a');
-    
- 
+   
+   
   }
+
 </script>
 <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_API_KEY'] %>&callback=initMap&libraries=places&language=ja" async defer>
 </script> 


### PR DESCRIPTION
# やりたいこと

geocoding APIをつかって、場所などを検索したら、国名と緯度を経度を取得して、

field_forに自動的に入力させたい。

### 環境

ruby 3.1.2

rails 7.0.4

gem “cocoon”

cocoon-js-vanilla使用(yarn で追加済)

方向性が2つあると思って書きました。どちらも途中で詰まっているので、方法等などご教授いただけないでしょうか？

## 方向性1　geocoding APIを取得するタイミングとともに、値を代入してくる。

用意されているテンプレートに取得した値を代入し、登録フォーム(field_for）を増やす。

### 問題点　用意されているテンプレートのinputタグをどうやってとってくるのかわからない。

new.html.erb

```ruby
<input id="address" class="border py-3 px-10 text-gray-700" placeholder="国名を入れてください">
<input type="button" value="Search" onclick="codeAddress()">
# geocodingに値を渡すフォーム

<%= form_with model: @plan, local: true do |f| %>
  <%= f.label :plan_name, class: %>
  <%= f.text_field :name, placeholder: 'plan_name', class: %>
  <div id='add' class='btn btn-secondry' ><%= link_to_add_association 'add', f, :countries, class:,
    data: {
           association_insertion_node: '#detail-association-insertion-point',
           association_insertion_method: 'append' }%>

  <%= f.fields_for :countries do |country| %>
   <%= render 'country_fields', f: country %>
  <% end %>
<% end %>
```

_*country_field.html.erb*

```ruby
<tr id='country_fields' class= 'nested-fields'>
  <td><%= f.text_field :name, placeholder: 'country_name', class:"country_name py-2 px-3 text-gray-700 " %>
  </td>
  <td><%= f.text_field :latitude, placeholder: 'latitude', class:"latitude py-2 px-3 text-gray-700 " %>
  </td>
  <td><%= f.text_field :longitude, placeholder: 'longitude', class:"longitude py-2 px-3 text-gray-700" %>
  </td>
  <td><%= link_to_remove_association "remove", f, class:'remove_bty btn btn-danger link link-hover' %>
  </td>
</tr>
```

生成されるタイミングのinputタグを指定したいのだが、どこで持ってこれるのかわかっていない。

検証ツールで確認

addボタンを押したタイミングで新しく追加されるtemplateは存在しているみたいです。

```ruby
<div id="add" class="btn btn-secondry"><a class="hover hover:link add_fields" data-association-insertion-node="#detail-association-insertion-point" data-association-insertion-method="append"
 data-association="country" data-associations="countries" data-association-insertion-template="<tr id='country_fields' class= 'nested-fields'>

  <td><input placeholder=&quot;country_name&quot; class=&quot;country_name py-2 px-3 text-gray-700 &quot; type=&quot;text&quot; 
       name=&quot;plan[countries_attributes][new_countries][name]&quot; id=&quot;plan_countries_attributes_new_countries_name&quot; />
  </td>

  <td><input placeholder=&quot;latitude&quot; class=&quot;latitude py-2 px-3 text-gray-700 &quot; type=&quot;text&quot; 
       name=&quot;plan[countries_attributes][new_countries][latitude]&quot; id=&quot;plan_countries_attributes_new_countries_latitude&quot; />
  </td>

  <td><input placeholder=&quot;longitude&quot; class=&quot;longitude py-2 px-3 text-gray-700&quot; type=&quot;text&quot; 
       name=&quot;plan[countries_attributes][new_countries][longitude]&quot; id=&quot;plan_countries_attributes_new_countries_longitude&quot; />
  </td>

  <td><input value=&quot;false&quot; autocomplete=&quot;off&quot; type=&quot;hidden&quot; 
       name=&quot;plan[countries_attributes][new_countries][_destroy]&quot; id=&quot;plan_countries_attributes_new_countries__destroy&quot; />
      <a class=&quot;remove_bty btn btn-danger link link-hover remove_fields dynamic&quot; href=&quot;#&quot;>remove</a>
  </td>
</tr>
" href="#">add</a>
            </div>
```

下記のコマンドで取得できるが HTMLCollectionとなり、templateをどう取得するべきかわからない。
HTMLCollection [a.hover.hover:link.add_fields]のような形となる。

```ruby
let template = document.getElementById('add').getElementsByTagName('a')
```

## 方向性2　geocoding apiで場所を取得した後に追加する

先にfield_forを追加した上で、あとでgeocodingAPIで取得した値を代入する。

### 問題点　どういった形でidを取得して来るのかわからない

cocoon-js-vanillaをつかって、field_forを追加すると、idの中身が日付＋counterとなっているみたい。

毎度 id = plan_countries_attributes_1676878911346_name の数字部分が変化していく。

その場合のどうやって、idを取得すべきなのかわからない。

追加したときのinputタグ

```ruby
<tr id="country_fields" class="nested-fields">
  <td><input placeholder="country_name" class="country_name " type="text" name="plan[countries_attributes][1676878911346][name]" id="plan_countries_attributes_1676878911346_name">
  </td>
  <td><input placeholder="latitude" class="latitude" type="text" name="plan[countries_attributes][1676878911346][latitude]" id="plan_countries_attributes_1676878911346_latitude">
  </td>
  <td><input placeholder="longitude" class="longitude" type="text" name="plan[countries_attributes][1676878911346][longitude]" id="plan_countries_attributes_1676878911346_longitude">
  </td>
  <td><input value="false" autocomplete="off" type="hidden" name="plan[countries_attributes][1676878911346][_destroy]" id="plan_countries_attributes_1676878911346__destroy">
      <a class="remove_bty btn btn-danger link link-hover remove_fields dynamic" href="#">remove</a>
  </td>
</tr>
```

cocoon-js-vanillaでの値が関わっていそうなところ。
createNewIDがIDの数字の部分を変えていると思われる。

- index.js
    
    ```jsx
    document.addEventListener('DOMContentLoaded', function () {
      var cocoonElementCounter = 0;
    
      var createNewID = function () {
        return (new Date().getTime() + cocoonElementCounter++);
      };
    
      var newcontentBraced = function (id) {
        return '[' + id + ']$1';
      };
    
      var newcontentUnderscored = function (id) {
        return '_' + id + '_$1';
      };
    
      var getInsertionNodeElem = function (insertionNode, insertionTraversal, thisNode) {
        if (!insertionNode) {
          return thisNode.parentNode;
        }
    
        if (typeof insertionNode === 'function') {
          if (insertionTraversal) {
            console.warn('association-insertion-traversal is ignored, because association-insertion-node is given as a function.');
          }
          return insertionNode(thisNode);
        }
    
        if (typeof insertionNode === 'string') {
          if (insertionTraversal) {
            return thisNode[insertionTraversal](insertionNode);
          } else {
            return insertionNode === 'this' ? thisNode : document.querySelector(insertionNode);
          }
        }
      };
    
      var cocoonDetach = function (node) {
        return node.parentElement.removeChild(node);
      };
    
      var cocoonGetPreviousSibling = function (elem, selector) {
        var sibling = elem.previousElementSibling;
    
        if (!selector) return sibling;
    
        while (sibling) {
          var match = sibling.matches(selector);
          if (match) return sibling;
          sibling = sibling.previousElementSibling;
        }
      };
    
      var cocoonAddFields = function (e, target) {
        e.preventDefault();
        e.stopPropagation();
    
        var thisNode = target;
        var assoc = thisNode.getAttribute('data-association');
        var assocs = thisNode.getAttribute('data-associations');
        var content = thisNode.getAttribute('data-association-insertion-template');
        var insertionMethod = thisNode.getAttribute('data-association-insertion-method') || thisNode.getAttribute('data-association-insertion-position') || 'before';
        var insertionNode = thisNode.getAttribute('data-association-insertion-node');
        var insertionTraversal = thisNode.getAttribute('data-association-insertion-traversal');
        var count = parseInt(thisNode.getAttribute('data-count'), 10);
        var regexpBraced = new RegExp('\\[new_' + assoc + '\\](.*?\\s)', 'g');
        var regexpUnderscored = new RegExp('_new_' + assoc + '_(\\w*)', 'g');
        var newId = createNewID();
        var newContent = content.replace(regexpBraced, newcontentBraced(newId));
        var newContents = [];
        var originalEvent = e;
    
        if (newContent === content) {
          regexpBraced = new RegExp('\\[new_' + assocs + '\\](.*?\\s)', 'g');
          regexpUnderscored = new RegExp('_new_' + assocs + '_(\\w*)', 'g');
          newContent = content.replace(regexpBraced, newcontentBraced(newId));
        }
    
        newContent = newContent.replace(regexpUnderscored, newcontentUnderscored(newId));
        newContents = [newContent];
    
        count = (isNaN(count) ? 1 : Math.max(count, 1));
        count -= 1;
    
        while (count) {
          newId = createNewID();
          newContent = content.replace(regexpBraced, newcontentBraced(newId));
          newContent = newContent.replace(regexpUnderscored, newcontentUnderscored(newId));
          newContents.push(newContent);
    
          count -= 1;
        }
    
        var insertionNodeElem = getInsertionNodeElem(insertionNode, insertionTraversal, thisNode);
    
        if (!insertionNodeElem || (insertionNodeElem.length === 0)) {
          console.warn("Couldn't find the element to insert the template. Make sure your `data-association-insertion-*` on `link_to_add_association` is correct.");
        }
    
        newContents.forEach(function (node, i) {
          var contentNode = node;
    
          var beforeInsert = new CustomEvent('cocoon:before-insert', { bubbles: true, cancelable: true, detail: [contentNode, originalEvent] });
          insertionNodeElem.dispatchEvent(beforeInsert);
    
          if (!beforeInsert.defaultPrevented) {
            // allow any of the jquery dom manipulation methods (after, before, append, prepend, etc)
            // to be called on the node.  allows the insertion node to be the parent of the inserted
            // code and doesn't force it to be a sibling like after/before does. default: 'before'
            var htmlMapping = {
              before: 'beforebegin',
              prepend: 'afterbegin',
              append: 'beforeend',
              after: 'afterend'
            };
    
            var htmlMethod = htmlMapping[insertionMethod];
            var addedContent = insertionNodeElem.insertAdjacentHTML(htmlMethod, contentNode);
    
            if (htmlMethod === htmlMapping.before) {
              addedContent = insertionNodeElem.previousElementSibling;
            } else if (htmlMethod === htmlMapping.prepend) {
              addedContent = insertionNodeElem.firstElementChild;
            } else if (htmlMethod === htmlMapping.append) {
              addedContent = insertionNodeElem.lastElementChild;
            } else if (htmlMethod === htmlMapping.after) {
              addedContent = insertionNodeElem.nextElementSibling;
            }
    
            var afterInsert = new CustomEvent('cocoon:after-insert', { bubbles: true, detail: [contentNode, originalEvent, addedContent] });
            insertionNodeElem.dispatchEvent(afterInsert);
          }
        });
      };
    
      var cocoonRemoveFields = function (e, target) {
        var thisNode = target;
        var wrapperClass = thisNode.getAttribute('data-wrapper-class') || 'nested-fields';
        var nodeToDelete = thisNode.closest('.' + wrapperClass);
        var triggerNode = nodeToDelete.parentNode;
        var originalEvent = e;
    
        e.preventDefault();
        e.stopPropagation();
    
        var beforeRemove = new CustomEvent('cocoon:before-remove', { bubbles: true, cancelable: true, detail: [nodeToDelete, originalEvent] });
        triggerNode.dispatchEvent(beforeRemove);
    
        if (!beforeRemove.defaultPrevented) {
          var timeout = triggerNode.getAttribute('data-remove-timeout') || 0;
    
          setTimeout(function () {
            if (thisNode.classList.contains('dynamic')) {
              cocoonDetach(nodeToDelete);
            } else {
              var hiddenInput = cocoonGetPreviousSibling(thisNode, 'input[type=hidden]');
              hiddenInput.value = '1';
              nodeToDelete.style.display = 'none';
            }
            var afterRemove = new CustomEvent('cocoon:after-remove', { bubbles: true, detail: [nodeToDelete, originalEvent] });
            triggerNode.dispatchEvent(afterRemove);
          }, timeout);
        }
      };
    
      document.addEventListener('click', function (e) {
        for (var target = e.target; target && target !== this; target = target.parentNode) {
          if (target.matches('.add_fields')) {
            cocoonAddFields(e, target);
            return;
          }
          if (target.matches('.remove_fields')) {
            cocoonRemoveFields(e, target);
            return;
          }
        }
      }, false);
    });
    
    // TODO - Test this
    // document.addEventListener("DOMContentLoaded page:load turbolinks:load", function () {
    //   var destroyedFields = document.querySelectorAll(".remove_fields.existing.destroyed");
    //   Array.prototype.forEach.call(destroyedFields, function (el) {
    //     var wrapperClass = el.getAttribute("data-wrapper-class") || "nested-fields";
    //     el.closest("." + wrapperClass).style.display = "none";
    //   });
    // });
    ```